### PR TITLE
feat: add main page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.formatOnSave": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript"]
 }

--- a/src/components/CategoryChips/index.tsx
+++ b/src/components/CategoryChips/index.tsx
@@ -3,15 +3,16 @@ import { Box, Typography } from '@mui/material';
 import Chip from '../Chip';
 import { Item } from '../../models/item';
 
-interface Props {
-  onClickHandler: (category: string, label: string, isSelected: boolean) => void;
+interface CategoryChipsProps {
+  handleCategoryChipsClick: (category: string, label: string, isSelected: boolean) => void;
   category: string;
   items: Item[];
 }
 
-export default function CategoryChips(props: Props) {
+export default function CategoryChips(props: CategoryChipsProps) {
+  const { category, items } = props;
   const handleChipClick = (label: string, isSelected: boolean) => {
-    props.onClickHandler(props.category, label, isSelected);
+    props.handleCategoryChipsClick(category, label, isSelected);
   };
   return (
     <Box
@@ -25,10 +26,10 @@ export default function CategoryChips(props: Props) {
       }}
     >
       <Typography variant="h6" sx={{ width: '70px', mr: 1.5, fontSize: 17, fontWeight: 'bold' }}>
-        {props.category}
+        {category}
       </Typography>
-      {props.items.map((item, index) => (
-        <Chip key={index} onClickHandler={handleChipClick} item={item} />
+      {items.map((item, index) => (
+        <Chip key={index} handleChipClick={handleChipClick} item={item} />
       ))}
     </Box>
   );

--- a/src/components/CategoryChips/index.tsx
+++ b/src/components/CategoryChips/index.tsx
@@ -1,29 +1,34 @@
 import { Box, Typography } from '@mui/material';
 
 import Chip from '../Chip';
+import { Item } from '../../models/item';
 
 interface Props {
+  onClickHandler: (category: string, label: string, isSelected: boolean) => void;
   category: string;
-  items: { label: string; isSelected: boolean }[];
+  items: Item[];
 }
 
 export default function CategoryChips(props: Props) {
+  const handleChipClick = (label: string, isSelected: boolean) => {
+    props.onClickHandler(props.category, label, isSelected);
+  };
   return (
     <Box
       display={'flex'}
       flexDirection={'row'}
       alignItems={'center'}
       sx={{
-        mt: 2,
+        mt: 1,
         backgroundColor: 'none',
         wrap: 'nowrap',
       }}
     >
-      <Typography variant="h4" sx={{ width: '70px', mr: 2, fontSize: 20, fontWeight: 'bold' }}>
+      <Typography variant="h6" sx={{ width: '70px', mr: 1.5, fontSize: 17, fontWeight: 'bold' }}>
         {props.category}
       </Typography>
       {props.items.map((item, index) => (
-        <Chip key={index} label={item.label} isSelected={item.isSelected} />
+        <Chip key={index} onClickHandler={handleChipClick} item={item} />
       ))}
     </Box>
   );

--- a/src/components/CategoryChips/index.tsx
+++ b/src/components/CategoryChips/index.tsx
@@ -1,0 +1,30 @@
+import { Box, Typography } from '@mui/material';
+
+import Chip from '../Chip';
+
+interface Props {
+  category: string;
+  items: { label: string; isSelected: boolean }[];
+}
+
+export default function CategoryChips(props: Props) {
+  return (
+    <Box
+      display={'flex'}
+      flexDirection={'row'}
+      alignItems={'center'}
+      sx={{
+        mt: 2,
+        backgroundColor: 'none',
+        wrap: 'nowrap',
+      }}
+    >
+      <Typography variant="h4" sx={{ width: '70px', mr: 2, fontSize: 20, fontWeight: 'bold' }}>
+        {props.category}
+      </Typography>
+      {props.items.map((item, index) => (
+        <Chip key={index} label={item.label} isSelected={item.isSelected} />
+      ))}
+    </Box>
+  );
+}

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -3,17 +3,18 @@ import { Button } from '@mui/material';
 
 import { Item } from '../../models/item';
 
-interface Props {
-  onClickHandler: (label: string, isSelected: boolean) => void;
+interface ChipProps {
+  handleChipClick: (label: string, isSelected: boolean) => void;
   item: Item;
 }
-export default function Chip(props: Props) {
-  const [isSelected, setisSelected] = useState(props.item.isSelected);
+export default function Chip(props: ChipProps) {
+  const { item } = props;
+  const [isSelected, setisSelected] = useState(item.isSelected);
   const handleClick = () => {
     setisSelected(!isSelected);
-    props.onClickHandler(props.item.label, !isSelected);
+    props.handleChipClick(item.label, !isSelected);
   };
-  return isSelected ? (
+  return (
     <Button
       onClick={handleClick}
       sx={{
@@ -22,30 +23,13 @@ export default function Chip(props: Props) {
         paddingInline: 1,
         color: 'black',
         fontSize: 13,
-        fontWeight: 'bold',
-        backgroundColor: '#D9D9D9',
+        fontWeight: isSelected ? 'bold' : 'medium',
+        backgroundColor: isSelected ? '#D9D9D9' : 'white',
         boxShadow: '0 0 0 1px black',
         borderRadius: 100,
       }}
     >
-      {props.item.label}
-    </Button>
-  ) : (
-    <Button
-      onClick={handleClick}
-      sx={{
-        mr: 2,
-        padding: 0,
-        paddingInline: 1,
-        color: 'black',
-        fontSize: 13,
-        fontWeight: 'medium',
-        backgroundColor: 'white',
-        boxShadow: '0 0 0 1px black',
-        borderRadius: 100,
-      }}
-    >
-      {props.item.label}
+      {item.label}
     </Button>
   );
 }

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -1,47 +1,51 @@
 import { useState } from 'react';
 import { Button } from '@mui/material';
 
-interface Props {
-  label: string;
-  isSelected: boolean;
-}
+import { Item } from '../../models/item';
 
+interface Props {
+  onClickHandler: (label: string, isSelected: boolean) => void;
+  item: Item;
+}
 export default function Chip(props: Props) {
-  const [isSelected, setisSelected] = useState(props.isSelected);
-  const clickHandler = () => setisSelected(!isSelected);
+  const [isSelected, setisSelected] = useState(props.item.isSelected);
+  const handleClick = () => {
+    setisSelected(!isSelected);
+    props.onClickHandler(props.item.label, !isSelected);
+  };
   return isSelected ? (
     <Button
-      onClick={clickHandler}
+      onClick={handleClick}
       sx={{
         mr: 2,
         padding: 0,
         paddingInline: 1,
         color: 'black',
-        fontSize: 15,
+        fontSize: 13,
         fontWeight: 'bold',
         backgroundColor: '#D9D9D9',
         boxShadow: '0 0 0 1px black',
         borderRadius: 100,
       }}
     >
-      {props.label}
+      {props.item.label}
     </Button>
   ) : (
     <Button
-      onClick={clickHandler}
+      onClick={handleClick}
       sx={{
         mr: 2,
         padding: 0,
         paddingInline: 1,
         color: 'black',
-        fontSize: 15,
+        fontSize: 13,
         fontWeight: 'medium',
         backgroundColor: 'white',
         boxShadow: '0 0 0 1px black',
         borderRadius: 100,
       }}
     >
-      {props.label}
+      {props.item.label}
     </Button>
   );
 }

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Button } from '@mui/material';
+
+interface Props {
+  label: string;
+  isSelected: boolean;
+}
+
+export default function Chip(props: Props) {
+  const [isSelected, setisSelected] = useState(props.isSelected);
+  const clickHandler = () => setisSelected(!isSelected);
+  return isSelected ? (
+    <Button
+      onClick={clickHandler}
+      sx={{
+        mr: 2,
+        padding: 0,
+        paddingInline: 1,
+        color: 'black',
+        fontSize: 15,
+        fontWeight: 'bold',
+        backgroundColor: '#D9D9D9',
+        boxShadow: '0 0 0 1px black',
+        borderRadius: 100,
+      }}
+    >
+      {props.label}
+    </Button>
+  ) : (
+    <Button
+      onClick={clickHandler}
+      sx={{
+        mr: 2,
+        padding: 0,
+        paddingInline: 1,
+        color: 'black',
+        fontSize: 15,
+        fontWeight: 'medium',
+        backgroundColor: 'white',
+        boxShadow: '0 0 0 1px black',
+        borderRadius: 100,
+      }}
+    >
+      {props.label}
+    </Button>
+  );
+}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
-import { Box, Button, TextField } from '@mui/material';
+import { Box, IconButton, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
 import CategoryChips from '../CategoryChips';
@@ -8,13 +8,13 @@ import { Item } from '../../models/item';
 import { getSearchAPICall } from '../../hooks/api/search/search';
 import { Categories, Seasons } from '../../data/enumLists';
 
-interface Props {
+interface SearchBarProps {
   searchKeyWord: string;
   categorySelected: string[];
   seasonSelected: string[];
 }
 
-export default function SearchBar(props: Props) {
+export default function SearchBar(props: SearchBarProps) {
   const navigate = useNavigate();
   const emptyStrArray: string[] = [];
   const [searchKeyWord, setSearchKeyWord] = useState('');
@@ -95,16 +95,13 @@ export default function SearchBar(props: Props) {
           fullWidth
           placeholder="다른 사람의 옷을 구경해보세요!"
           onChange={handleChange}
-          sx={{ border: 'none', borderRadius: 100, margin: 0, backgroundColor: 'white' }}
+          sx={{ margin: 0, backgroundColor: 'white', borderRadius: 1 }}
         />
-        <Button
+        <IconButton
           type="submit"
-          variant="contained"
           sx={{
             position: 'absolute',
-            paddingInline: 0,
-            border: 'none',
-            backgroundColor: 'white',
+            backgroundColor: 'none',
             right: 10,
           }}
         >
@@ -113,7 +110,7 @@ export default function SearchBar(props: Props) {
               color: 'black',
             }}
           ></SearchIcon>
-        </Button>
+        </IconButton>
       </Box>
       <Box
         width={800}
@@ -127,9 +124,9 @@ export default function SearchBar(props: Props) {
           '& .MuiTextField-root': { margin: 1 },
         }}
       >
-        <CategoryChips onClickHandler={handleChipState} category="카테고리" items={initCategories} />
-        <CategoryChips onClickHandler={handleChipState} category="계절" items={initSeasons} />
-        <CategoryChips onClickHandler={handleChipState} category="필터" items={initFilter} />
+        <CategoryChips handleCategoryChipsClick={handleChipState} category="카테고리" items={initCategories} />
+        <CategoryChips handleCategoryChipsClick={handleChipState} category="계절" items={initSeasons} />
+        <CategoryChips handleCategoryChipsClick={handleChipState} category="필터" items={initFilter} />
       </Box>
     </Box>
   );

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,10 +1,15 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { useState, useSearchParams } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useSnackbar } from 'notistack';
 import axios, { AxiosError } from 'axios';
-import { Typography, Box } from '@mui/material';
+import { Box, Button, TextField } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+
+import { SEARCH_MESSAGE } from '../../data/messages';
 
 export default function SearchBar() {
   const navigate = useNavigate();
+  const { enqueueSnackbar } = useSnackbar();
   const [searchKeyWord, setSearchKeyWord] = useState('');
   // const [searchParams, setSearchParams] = useSearchParams();
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -15,13 +20,15 @@ export default function SearchBar() {
     try {
       const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, searchKeyWord);
       if (response.status === 200) {
-        const { name, image, owner } = response.data; // isWished도 필요
+        const { searchResult } = response.data; // isWished도 필요
+        sessionStorage.setItem('searchResult', searchResult);
+        navigate('/search');
       }
     } catch (err) {
       if (err instanceof AxiosError) {
         enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
       } else {
-        enqueueSnackbar(LOGIN_MESSAGE.LOGIN_FAIL, { variant: 'error' });
+        enqueueSnackbar(SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
       }
     }
   }
@@ -31,15 +38,37 @@ export default function SearchBar() {
   };
 
   return (
-    <Box sx={{ width: '100%', height: '25%', bgcolor: 'white', marginTop: 1 }}>
-      <Typography
-        component={Link}
-        to="/"
-        variant="h4"
-        sx={{ paddingLeft: 3, fontWeight: 'bold', color: 'black', textDecoration: 'none' }}
+    <Box display={'flex'} flexDirection={'column'} alignItems={'center'}>
+      <Box
+        component="form"
+        width={800}
+        height={150}
+        marginTop={15}
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          '& .MuiTextField-root': { margin: 1 },
+          borderRadius: 100,
+          borderColor: 'black',
+          wrap: 'nowrap',
+        }}
+        onSubmit={handleSubmit}
       >
-        StyleVillage
-      </Typography>
+        <TextField
+          id="searchKeyWord"
+          name="searchKeyWord"
+          type="searchKeyWord"
+          size="small"
+          fullWidth
+          placeholder="다른 사람의 옷을 구경해보세요!"
+          onChange={handleChange}
+          sx={{ border: 'none' }}
+        />
+        <Button type="submit" variant="contained" sx={{ marginTop: 2, width: 120, height: 120, border: 'none' }}>
+          <SearchIcon></SearchIcon>
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -8,7 +8,13 @@ import { Item } from '../../models/item';
 import { getSearchAPICall } from '../../hooks/api/search/search';
 import { Categories, Seasons } from '../../data/enumLists';
 
-export default function SearchBar() {
+interface Props {
+  searchKeyWord: string;
+  categorySelected: string[];
+  seasonSelected: string[];
+}
+
+export default function SearchBar(props: Props) {
   const navigate = useNavigate();
   const emptyStrArray: string[] = [];
   const [searchKeyWord, setSearchKeyWord] = useState('');
@@ -49,10 +55,18 @@ export default function SearchBar() {
   };
 
   const initCategories = Categories.map((value) => {
+    if (props.categorySelected.includes(value)) {
+      const item: Item = { label: value, isSelected: true };
+      return item;
+    }
     const item: Item = { label: value, isSelected: false };
     return item;
   });
   const initSeasons = Seasons.map((value) => {
+    if (props.seasonSelected.includes(value)) {
+      const item: Item = { label: value, isSelected: true };
+      return item;
+    }
     const item: Item = { label: value, isSelected: false };
     return item;
   });

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,57 +1,82 @@
-import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
-import { useSnackbar } from 'notistack';
-import axios, { AxiosError } from 'axios';
 import { Box, Button, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
-import { SEARCH_MESSAGE } from '../../data/messages';
+import CategoryChips from '../CategoryChips';
+import { Item } from '../../models/item';
+import { Categories, Seasons } from '../../data/enumLists';
 
 export default function SearchBar() {
-  const navigate = useNavigate();
-  const { enqueueSnackbar } = useSnackbar();
-  const [searchKeyWord, setSearchKeyWord] = useState('');
-  // const [searchParams, setSearchParams] = useSearchParams();
+  const emptyStrArray: string[] = [];
+
+  const [, setSearchKeyWord] = useState('');
+  const [categorySelected, setCategorySelected] = useState(emptyStrArray);
+  const [seasonSelected, setSeasonSelected] = useState(emptyStrArray);
+  const [filterSelected, setFilterSelected] = useState(emptyStrArray);
+
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     setSearchKeyWord(event.target.value);
   };
 
-  async function Search() {
-    try {
-      const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, searchKeyWord);
-      if (response.status === 200) {
-        const { searchResult } = response.data; // isWished도 필요
-        sessionStorage.setItem('searchResult', searchResult);
-        navigate('/search');
-      }
-    } catch (err) {
-      if (err instanceof AxiosError) {
-        enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
-      } else {
-        enqueueSnackbar(SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
-      }
-    }
-  }
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    Search();
   };
+
+  const handleChipState = (category: string, label: string, isSelected: boolean) => {
+    switch (category) {
+      case '카테고리':
+        setCategorySelected(isSelected ? [...categorySelected, label] : categorySelected.filter((c) => c !== label));
+        break;
+      case '계절':
+        setSeasonSelected(isSelected ? [...seasonSelected, label] : seasonSelected.filter((c) => c !== label));
+        break;
+      case '필터':
+        setFilterSelected(isSelected ? [...filterSelected, label] : filterSelected.filter((c) => c !== label));
+        break;
+      default:
+        break;
+    }
+  };
+
+  const initCategories = Categories.map((value) => {
+    const item: Item = { label: value, isSelected: false };
+    return item;
+  });
+  const initSeasons = Seasons.map((value) => {
+    const item: Item = { label: value, isSelected: false };
+    return item;
+  });
+  const initFilter: Item[] = [{ label: '대여 가능', isSelected: false }];
+
+  // async function Search() {
+  //   try {
+  //     const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, searchKeyWord);
+  //     if (response.status === 200) {
+  //       const { searchResult } = response.data; // isWished도 필요
+  //       sessionStorage.setItem('searchResult', searchResult);
+  //       navigate('/search');
+  //     }
+  //   } catch (err) {
+  //     if (err instanceof AxiosError) {
+  //       enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
+  //     } else {
+  //       enqueueSnackbar(SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
+  //     }
+  //   }
+  // }
 
   return (
     <Box display={'flex'} flexDirection={'column'} alignItems={'center'}>
       <Box
         component="form"
+        position="relative"
         width={800}
-        height={150}
-        marginTop={15}
+        height="50px"
+        marginTop={1}
         sx={{
           display: 'flex',
-          flexDirection: 'row',
           alignItems: 'center',
           '& .MuiTextField-root': { margin: 1 },
-          borderRadius: 100,
-          borderColor: 'black',
-          wrap: 'nowrap',
         }}
         onSubmit={handleSubmit}
       >
@@ -63,11 +88,41 @@ export default function SearchBar() {
           fullWidth
           placeholder="다른 사람의 옷을 구경해보세요!"
           onChange={handleChange}
-          sx={{ border: 'none' }}
+          sx={{ border: 'none', borderRadius: 100, margin: 0, backgroundColor: 'white' }}
         />
-        <Button type="submit" variant="contained" sx={{ marginTop: 2, width: 120, height: 120, border: 'none' }}>
-          <SearchIcon></SearchIcon>
+        <Button
+          type="submit"
+          variant="contained"
+          sx={{
+            position: 'absolute',
+            paddingInline: 0,
+            border: 'none',
+            backgroundColor: 'white',
+            right: 10,
+          }}
+        >
+          <SearchIcon
+            sx={{
+              color: 'black',
+            }}
+          ></SearchIcon>
         </Button>
+      </Box>
+      <Box
+        width={800}
+        height="150px"
+        marginTop={1}
+        marginLeft={5}
+        display={'flex'}
+        flexDirection={'column'}
+        alignItems={'left'}
+        sx={{
+          '& .MuiTextField-root': { margin: 1 },
+        }}
+      >
+        <CategoryChips onClickHandler={handleChipState} category="카테고리" items={initCategories} />
+        <CategoryChips onClickHandler={handleChipState} category="계절" items={initSeasons} />
+        <CategoryChips onClickHandler={handleChipState} category="필터" items={initFilter} />
       </Box>
     </Box>
   );

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,25 +1,23 @@
+import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { Box, Button, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
 import CategoryChips from '../CategoryChips';
 import { Item } from '../../models/item';
+import { getSearchAPICall } from '../../hooks/api/search/search';
 import { Categories, Seasons } from '../../data/enumLists';
 
 export default function SearchBar() {
+  const navigate = useNavigate();
   const emptyStrArray: string[] = [];
-
-  const [, setSearchKeyWord] = useState('');
+  const [searchKeyWord, setSearchKeyWord] = useState('');
   const [categorySelected, setCategorySelected] = useState(emptyStrArray);
   const [seasonSelected, setSeasonSelected] = useState(emptyStrArray);
   const [filterSelected, setFilterSelected] = useState(emptyStrArray);
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     setSearchKeyWord(event.target.value);
-  };
-
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
   };
 
   const handleChipState = (category: string, label: string, isSelected: boolean) => {
@@ -38,6 +36,18 @@ export default function SearchBar() {
     }
   };
 
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const values = {
+      categories: categorySelected,
+      seasons: seasonSelected,
+      text: searchKeyWord,
+    };
+    getSearchAPICall(values).then(() => {
+      navigate('/');
+    });
+  };
+
   const initCategories = Categories.map((value) => {
     const item: Item = { label: value, isSelected: false };
     return item;
@@ -47,23 +57,6 @@ export default function SearchBar() {
     return item;
   });
   const initFilter: Item[] = [{ label: '대여 가능', isSelected: false }];
-
-  // async function Search() {
-  //   try {
-  //     const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, searchKeyWord);
-  //     if (response.status === 200) {
-  //       const { searchResult } = response.data; // isWished도 필요
-  //       sessionStorage.setItem('searchResult', searchResult);
-  //       navigate('/search');
-  //     }
-  //   } catch (err) {
-  //     if (err instanceof AxiosError) {
-  //       enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
-  //     } else {
-  //       enqueueSnackbar(SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
-  //     }
-  //   }
-  // }
 
   return (
     <Box display={'flex'} flexDirection={'column'} alignItems={'center'}>

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -19,7 +19,7 @@ export default function SearchBar() {
       }
     } catch (err) {
       if (err instanceof AxiosError) {
-        enqueueSnackbar(err.response?.data?.message ?? LOGIN_MESSAGE.LOGIN_FAIL, { variant: 'error' });
+        enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
       } else {
         enqueueSnackbar(LOGIN_MESSAGE.LOGIN_FAIL, { variant: 'error' });
       }
@@ -27,7 +27,7 @@ export default function SearchBar() {
   }
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    Login();
+    Search();
   };
 
   return (

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,0 +1,45 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useState, useSearchParams } from 'react';
+import axios, { AxiosError } from 'axios';
+import { Typography, Box } from '@mui/material';
+
+export default function SearchBar() {
+  const navigate = useNavigate();
+  const [searchKeyWord, setSearchKeyWord] = useState('');
+  // const [searchParams, setSearchParams] = useSearchParams();
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    setSearchKeyWord(event.target.value);
+  };
+
+  async function Search() {
+    try {
+      const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, searchKeyWord);
+      if (response.status === 200) {
+        const { name, image, owner } = response.data; // isWished도 필요
+      }
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        enqueueSnackbar(err.response?.data?.message ?? LOGIN_MESSAGE.LOGIN_FAIL, { variant: 'error' });
+      } else {
+        enqueueSnackbar(LOGIN_MESSAGE.LOGIN_FAIL, { variant: 'error' });
+      }
+    }
+  }
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    Login();
+  };
+
+  return (
+    <Box sx={{ width: '100%', height: '25%', bgcolor: 'white', marginTop: 1 }}>
+      <Typography
+        component={Link}
+        to="/"
+        variant="h4"
+        sx={{ paddingLeft: 3, fontWeight: 'bold', color: 'black', textDecoration: 'none' }}
+      >
+        StyleVillage
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -44,13 +44,18 @@ export default function SearchBar(props: SearchBarProps) {
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    const values = {
-      categories: categorySelected,
-      seasons: seasonSelected,
-      text: searchKeyWord,
-    };
-    getSearchAPICall(values).then(() => {
-      navigate('/');
+    const keyWordQueryString = `keyword=${encodeURIComponent(searchKeyWord)}`;
+    const categoryQueryString = categorySelected
+      .map((category) => `category=${encodeURIComponent(category)}`)
+      .join('&');
+    const seasonQueryString = seasonSelected.map((season) => `season=${encodeURIComponent(season)}`).join('&');
+    const filterQueryString = filterSelected.map((filter) => `filter=${encodeURIComponent(filter)}`).join('&');
+    const queryString = [keyWordQueryString, categoryQueryString, seasonQueryString, filterQueryString]
+      .filter((query) => !!query)
+      .join('&');
+    const url = `/search/?${queryString}`;
+    getSearchAPICall(url).then(() => {
+      navigate(url);
     });
   };
 

--- a/src/data/enumLists.ts
+++ b/src/data/enumLists.ts
@@ -1,0 +1,4 @@
+import { Season, Category } from '../models/enum';
+
+export const Seasons = Object.values(Season);
+export const Categories = Object.values(Category);

--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -1,3 +1,7 @@
 export const LOGIN_MESSAGE = {
   LOGIN_FAIL: '로그인에 실패하였습니다 :(',
 };
+
+export const SEARCH_MESSAGE = {
+  SEARCH_FAIL: '검색에 실패하였습니다 :(',
+};

--- a/src/hooks/api/search/search.ts
+++ b/src/hooks/api/search/search.ts
@@ -1,0 +1,27 @@
+import { enqueueSnackbar } from 'notistack';
+import axios, { AxiosError } from 'axios';
+
+import { SEARCH_MESSAGE } from '../../../data/messages';
+
+export interface Search {
+  // filter 추가해야 함.
+  categories: string[];
+  seasons: string[];
+  text: string;
+}
+
+export async function getSearchAPICall(values: Search) {
+  try {
+    const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, values);
+    if (response.status === 200) {
+      const { searchResult } = response.data; // isWished도 필요
+      sessionStorage.setItem('searchResult', searchResult);
+    }
+  } catch (err) {
+    if (err instanceof AxiosError) {
+      enqueueSnackbar(err.response?.data?.message ?? SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
+    } else {
+      enqueueSnackbar(SEARCH_MESSAGE.SEARCH_FAIL, { variant: 'error' });
+    }
+  }
+}

--- a/src/hooks/api/search/search.ts
+++ b/src/hooks/api/search/search.ts
@@ -3,16 +3,9 @@ import axios, { AxiosError } from 'axios';
 
 import { SEARCH_MESSAGE } from '../../../data/messages';
 
-export interface Search {
-  /* TODO: filter 추가 */
-  categories: string[];
-  seasons: string[];
-  text: string;
-}
-
-export async function getSearchAPICall(values: Search) {
+export async function getSearchAPICall(url: string) {
   try {
-    const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, values);
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}${url}`);
     if (response.status === 200) {
       const { searchResult } = response.data;
       sessionStorage.setItem('searchResult', searchResult);

--- a/src/hooks/api/search/search.ts
+++ b/src/hooks/api/search/search.ts
@@ -4,7 +4,7 @@ import axios, { AxiosError } from 'axios';
 import { SEARCH_MESSAGE } from '../../../data/messages';
 
 export interface Search {
-  // filter 추가해야 함.
+  /* TODO: filter 추가 */
   categories: string[];
   seasons: string[];
   text: string;
@@ -14,7 +14,7 @@ export async function getSearchAPICall(values: Search) {
   try {
     const response = await axios.post(`${process.env.REACT_APP_API_URL}/search/`, values);
     if (response.status === 200) {
-      const { searchResult } = response.data; // isWished도 필요
+      const { searchResult } = response.data;
       sessionStorage.setItem('searchResult', searchResult);
     }
   } catch (err) {

--- a/src/models/enum.ts
+++ b/src/models/enum.ts
@@ -1,0 +1,34 @@
+export enum Category {
+  MINISKIRT = '미니스커트',
+  MIDISKIRT = '미디스커트',
+  LONGSKIRT = '롱스커트',
+}
+
+export enum City {
+  SEOUL = '서울',
+  INCHEON = '인천',
+  DAEJOEN = '대전',
+  BUSAN = '부산',
+  DAEGU = '대구',
+  GWANGJU = '광주',
+  SEJONG = '세종',
+  ULSAN = '울산',
+}
+
+export enum Gender {
+  MALE = '남성',
+  FEMALE = '여성',
+}
+
+export enum Season {
+  SPRING = '봄',
+  SUMMER = '여름',
+  FALL = '가을',
+  WINTER = '겨울',
+}
+
+export enum Status {
+  AVAILABLE = '대여가능',
+  UNAVAILABLE = '대여불가능',
+  RENTED = '대여중',
+}

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -1,0 +1,4 @@
+export interface Item {
+  label: string;
+  isSelected: boolean;
+}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -13,7 +13,7 @@ export function MainPage() {
           스타일을 공유하고 다른 사람의 스타일을 빌려보세요
         </Typography>
       </Box>
-      <SearchBar />
+      <SearchBar searchKeyWord={''} categorySelected={[]} seasonSelected={[]} />
     </Box>
   );
 }

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -4,7 +4,7 @@ import SearchBar from '../../components/SearchBar';
 
 export function MainPage() {
   return (
-    <Box sx={{ marginTop: 0, backgroundColor: '#D9D9D9' }}>
+    <Box sx={{ marginTop: 0, backgroundColor: '#E9E9E9' }}>
       <Box paddingTop={5} display={'flex'} flexDirection={'column'} alignItems={'center'}>
         <Typography variant="h1" sx={{ fontWeight: 'bold' }}>
           StyleVillage

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { Box, Typography } from '@mui/material';
 
 import { User } from '../../models/user';
+import CategoryChips from '../../components/CategoryChips';
 
 export function MainPage() {
   /**
@@ -67,6 +68,11 @@ export function MainPage() {
     getUser();
   }, []);
 
+  const items = [
+    { label: '아이', isSelected: true },
+    { label: '아아dkdkdkdkdk', isSelected: false },
+  ];
+
   return (
     <Box paddingX={3} paddingY={5}>
       <Box>
@@ -78,6 +84,8 @@ export function MainPage() {
         <Typography variant="h6">성: {user.lastName}</Typography>
         <Typography variant="h6">나이: {user.age}</Typography>
       </Box>
+      <CategoryChips category="카테고리" items={items} />
+      <CategoryChips category="나라" items={items} />
     </Box>
   );
 }

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,91 +1,19 @@
-import { useEffect, useState } from 'react';
-import axios from 'axios';
 import { Box, Typography } from '@mui/material';
 
-import { User } from '../../models/user';
-import CategoryChips from '../../components/CategoryChips';
+import SearchBar from '../../components/SearchBar';
 
 export function MainPage() {
-  /**
-   * user 상태(state)를 선언했습니다.
-   * 이 state는 User 타입이며, 초기값은 아래와 같습니다.
-   */
-  const [user, setUser] = useState<User>({
-    id: 0,
-    firstName: '이웹',
-    lastName: '케',
-    age: 21,
-  });
-
-  /**
-   * 백엔드 서버에 요청을 보내서 유저 정보를 가져오는 함수입니다.
-   * 이런 api호출하는데 axios 라이브러리를 많이 사용합니다.
-   * 서버와 통신하는데 시간이 걸리기 때문에 비동기 함수(async)로 선언했습니다.
-   * 비동기 함수는 항상 try-catch문으로 감싸주는 것이 좋습니다. (에러가 발생할 수 있기 때문에)
-   */
-  async function getUser() {
-    try {
-      /**
-       * process.env 는 환경변수를 의미합니다
-       * .env 파일에 REACT_APP_API_URL 이라는 변수를 선언했기 때문에 이런식으로 불러올 수 있습니다.
-       * 실행되는 환경(개발이냐 라이브냐)에 따라 달라지는 값이거나, 보안이 필요한 값들은 .env 파일에 넣어두고 불러와서 사용합니다.
-       * .env 파일은 git에 올라가지 않습니다.(지금은 교육용으로 올려놨습니다)
-       * .env 파일은 .gitignore에 등록되어 있습니다.
-       *
-       * axios.get()은 여러 값들을 반환하지만, 우리는 data, status만 사용할 것입니다.
-       * data라는 이름은 너무 추상적이기 때문에 userResponse라는 이름으로 사용합니다.
-       */
-      const { data: userResponse, status } = await axios.get(`${process.env.REACT_APP_API_URL}/user?id=1`);
-      if (status === 200) {
-        /**
-         * status가 200이라는 것은 서버로부터 제대로 데이터를 받아왔다는 것이므로, 우리는 user 상태를 업데이트해줍니다.
-         */
-        setUser(userResponse);
-      } else {
-        // 실패한 경우, 에러를 발생시킵니다.
-        // 이러면 아래의 catch문으로 넘어갑니다.
-        throw new Error();
-      }
-    } catch {
-      /**
-       * 모종의 이유로 api 호출에 실패한 경우, 에러를 콘솔에 출력합니다. (실제 사용자에게는 보이지 않습니다.)
-       */
-      console.error('유저 정보를 가져오는데 실패했습니다.');
-    }
-  }
-
-  /**
-   * useEffect는 컴포넌트가 렌더링 될 때마다 실행되는 함수입니다.
-   * 두번째 인자로 빈 배열을 넣어주면, 컴포넌트가 처음 렌더링 될 때만 실행됩니다.
-   * 이런식으로 사용하면, 컴포넌트가 처음 렌더링 될 때만 실행되는 코드를 작성할 수 있습니다.
-   * (처음 렌더링 될 때만 실행되는 코드는 보통 api 호출 코드입니다.) -> api 호출은 렌더링된 후 딱 한 번만 실행해야 합니다.
-   * api 호출하는 액션 자체만으로 프론트나 백엔드나 성능이 저하됩니다.
-   *
-   * deps(=의존성) 배열이 빈 배열이므로 첫 렌더링 때만 실행됩니다.
-   * 만약 의존성 배열에 어떠한 변수나 상태를 넣어주면, 해당 변수나 상태가 변경될 때마다 실행됩니다. -> 상황에 따라 유용하게 사용할 수 있습니다.
-   */
-  useEffect(() => {
-    getUser();
-  }, []);
-
-  const items = [
-    { label: '아이', isSelected: true },
-    { label: '아아dkdkdkdkdk', isSelected: false },
-  ];
-
   return (
-    <Box paddingX={3} paddingY={5}>
-      <Box>
-        <Typography variant="h4">사용자 정보</Typography>
+    <Box sx={{ marginTop: 0, backgroundColor: '#D9D9D9' }}>
+      <Box paddingTop={5} display={'flex'} flexDirection={'column'} alignItems={'center'}>
+        <Typography variant="h1" sx={{ fontWeight: 'bold' }}>
+          StyleVillage
+        </Typography>
+        <Typography variant="h6" sx={{ mt: 2, fontWeight: 'semi-bold', marginBottom: 2 }}>
+          스타일을 공유하고 다른 사람의 스타일을 빌려보세요
+        </Typography>
       </Box>
-      <Box height={40} />
-      <Box>
-        <Typography variant="h6">이름: {user.firstName}</Typography>
-        <Typography variant="h6">성: {user.lastName}</Typography>
-        <Typography variant="h6">나이: {user.age}</Typography>
-      </Box>
-      <CategoryChips category="카테고리" items={items} />
-      <CategoryChips category="나라" items={items} />
+      <SearchBar />
     </Box>
   );
 }


### PR DESCRIPTION
메인 페이지의 상단 요소들을 구현했습니다.
검색 API가 아직 완성되지 않아서 api가 제대로 작동하는지 테스트해보지는 못했습니다.

현재 페이지 모습입니다. 
![image](https://github.com/KWEBofficial/stylevillage-client/assets/129672066/5f7c6a65-eb44-4dd2-87cb-5487c793add4)


아래 컴포넌트를 만들었습니다.
1. Chip
2. CategoryChips
3. SearchBar

해결 못했거나 궁금한 부분입니다.
디자인 관련
1. 검색 입력란 안에 버튼을 깔끔하게 넣는 방법을 모르겠습니다.
2. 버튼과 textfield에 기본으로 들어가 있는 설정을 없앨 수 있는지 궁금합니다.
3. textfiled의 border가 변경이 안되던데 아예 변경할 수 있는 방법이 없는 건가요?

기능 관련
5. 검색 결과를 session에 저장하는 게 맞나요?
6. 저희가 검색 구현을 body로 받아서 하기로 했으니까 query는 안 건드려도 되는 거 맞나요?

추가로 검색 api에 대여가능 필터도 추가해야 할 것 같습니다.
